### PR TITLE
DMT-19 Add CI/CD related references to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,15 @@ The Donut Mod is an extension addon for the TIBCO Spotfire platform, which compl
 
 A complete guide to installation and getting started using mod can be found [here.](/documentation/user_guide.md)
 
-## System Architecture 
+## Technical Overview
+
+### System Architecture 
 
 [Overview of the system architecture.](/documentation/architecture.md)
+
+### Continuous Integration / Continuous Deployment
+
+[Details on the current stage of the CI/CD pipelines.](/documentation/ci-cd.md)
 
 ## Team
 

--- a/documentation/ci-cd.md
+++ b/documentation/ci-cd.md
@@ -1,0 +1,11 @@
+# Continuous Integration / Continuous Deployment
+
+## Continuous Integration pipeline
+
+The integration of a CI pipeline to the development workflow of the `Donut-Mod` has the purpose of automating the build and testing processes, every time a code is pushed to the branches. Therefore, it aims to increase the confidence of the team that newly introduced code is automatically checked, of course, depending on the corresponding configuration of the pipeline and the tests that exist.
+
+Based on the current development stage, the pipeline currently only checks if the installation process of the needed Node.js related packages is succeeding. However, in the future its configuration shall be extended, as more functionality is expected to be added, by the implementation of new features.
+
+## Continuous Deployment
+
+Currently, there has been no need to create a CD pipeline yet. However, depending on possible requirements' updates, a pipeline that automates the deployment process *may* be introduced.


### PR DESCRIPTION
## Proposed changes
- Add `ci-cd.md` file that contains information on the current stage of the CI/CD pipelines.
- Updated the `README.md` file to contain a reference to the `ci-cd.md` documentation file.

## Additional information
- Moved the `System Architecture` and the `CI/CD` sections under the newly introduced parent section of `Technical Overview` in the `README.md`.
