### PR TITLE
DMT-30 Add labels to the partitions of the visualization

### DIFF
--- a/src/donutState.js
+++ b/src/donutState.js
@@ -53,10 +53,12 @@ export async function createDonutState(mod) {
     let sumOfValues = 0;
     let data = colorLeaves.map((leaf) => {
         let rows = leaf.rows();
-        sumOfValues += sumValue(rows, "Y");
+        let yValue = sumValue(rows, "Y")
+        sumOfValues += Math.abs(yValue);
         return {
             color: rows.length ? rows[0].color().hexCode : "transparent",
-            value: sumValue(rows, "Y"),
+            value: yValue,
+            absValue: Math.abs(yValue),
             id: leaf.key,
             mark: () => leaf.mark(),
             tooltip: () => {

--- a/src/donutState.js
+++ b/src/donutState.js
@@ -50,8 +50,10 @@ export async function createDonutState(mod) {
 
     let colorLeaves = colorRoot.leaves();
 
+    let sumOfValues = 0;
     let data = colorLeaves.map((leaf) => {
         let rows = leaf.rows();
+        sumOfValues += sumValue(rows, "Y");
         return {
             color: rows.length ? rows[0].color().hexCode : "transparent",
             value: sumValue(rows, "Y"),
@@ -71,6 +73,7 @@ export async function createDonutState(mod) {
         dataView: dataView,
         modControls: mod.controls,
         context: context,
+        sumOfValues: sumOfValues,
         clearMarking: () => dataView.clearMarking()
     };
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -16,7 +16,7 @@ export async function render(donutState) {
 
     const svg = d3.select("#mod-container svg g").attr("transform", `translate(${width / 2}, ${height / 2})`);
 
-    const pie = d3.pie().value((d) => d.value);
+    const pie = d3.pie().value((d) => d.absValue);
 
 
     const arc = d3
@@ -52,7 +52,7 @@ export async function render(donutState) {
         .attr("class", "sector")
         .transition()
         .duration(animationDuration)
-        .attr("value", (d) => (d.data.value / donutState.sumOfValues * 100).toFixed(1))
+        .attr("value", (d) => (calculatePercentageValue(d)))
         .attr("fill", (d) => d.data.color)
         .attrTween("d", tweenArc)
         .attr("stroke", "none");
@@ -119,12 +119,12 @@ export async function render(donutState) {
 
     }
 
-    // Calculates the percentage value for a set numerator and denominator and returns it
+    // Calculates the percentage value for the specific data and returns it
     // with a set "decimalPlaces" accuracy
     //http://www.jacklmoore.com/notes/rounding-in-javascript/
     function calculatePercentageValue(d) {
         let decimalPlaces = 1;
-        return Number(Math.round(parseFloat((d.data.value / donutState.sumOfValues * 100) + 'e' + decimalPlaces)) + 'e-' + decimalPlaces);
+        return Number(Math.round(parseFloat((d.data.absValue / donutState.sumOfValues * 100) + 'e' + decimalPlaces)) + 'e-' + decimalPlaces);
     }
 
     donutState.context.signalRenderComplete();

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,6 +1,6 @@
 import * as d3 from "d3";
 /**
- * @param {donutState} donutState
+ * @param {object} donutState
  */
 export async function render(donutState) {
     // Added a constant to remove the magic numbers within the width, height and radius calculations.
@@ -14,7 +14,7 @@ export async function render(donutState) {
 
     d3.select("#mod-container svg").attr("width", width).attr("height", height);
 
-    const svg = d3.select("#mod-container svg g").attr("transform", `translate(${width / 2}, ${height / 2})`);
+    const svg = d3.select("#mod-container").select("svg#svg").attr("transform", `translate(${width / 2}, ${height / 2})`);
 
     const pie = d3.pie().value((d) => d.value);
 
@@ -25,13 +25,14 @@ export async function render(donutState) {
         .outerRadius(radius);
 
     // Join new data
-    const sectors = svg.selectAll("path").data(pie(donutState.data), (d) => {
+    const sectors = svg.select("g#sectors").selectAll("path").data(pie(donutState.data), (d) => {
         return d.data.id;
     });
 
     let newSectors = sectors
         .enter()
-        .append("path")
+        .append("svg:path")
+        .attr("class", "sector")
         .on("click", function (d) {
             d.data.mark();
         })
@@ -45,11 +46,41 @@ export async function render(donutState) {
 
     sectors
         .merge(newSectors)
+        .attr("class", "sector")
         .transition()
         .duration(animationDuration)
+        .attr("value", (d) => (d.data.value / donutState.sumOfValues * 100).toFixed(1))
         .attr("fill", (d) => d.data.color)
         .attrTween("d", tweenArc)
         .attr("stroke", "none");
+
+    sectors.exit().transition().duration(animationDuration).attr("fill", "transparent").remove();
+
+    svg.select("g#labels")
+        .attr("pointer-events", "none")
+        .attr("text-anchor", "middle")
+        .selectAll("text")
+        .data(pie(donutState.data), (d) => `label-${d.data.id}`)
+        .join(
+            (enter) => {
+                return enter
+                    .append("text")
+                    .style("opacity", 0)
+                    .attr("dy", "0.35em")
+                    .attr("font-size", 40)
+                    .attr("fill", "transparent")
+                    .text((d) => (d.data.value / donutState.sumOfValues * 100).toFixed(1))
+                    .call((enter) =>
+                        enter
+                            .transition("add labels")
+                            .duration(animationDuration)
+                            .style("opacity", 1)
+                            .attrTween("transform", tweenTransform)
+                    );
+            },
+            (exit) => exit.transition("remove labels").duration(animationDuration).style("opacity", 0).remove()
+        );
+
 
     function tweenArc(elem) {
         let prevValue = this.__prev || {};
@@ -63,7 +94,25 @@ export async function render(donutState) {
         };
     }
 
-    sectors.exit().transition().duration(animationDuration).attr("fill", "transparent").remove();
+    function tweenTransform(data) {
+        let prevValue = this.__prev ? getTransformData(this.__prev) : {};
+        let newValue = getTransformData(data);
+        this.__prev = newValue;
+
+        var i = d3.interpolate(prevValue, newValue);
+
+        return function (value) {
+            var { x, y } = labelPosition(i(value));
+            return `rotate(${x - 90}) translate(${y},0) rotate(${Math.sin((Math.PI * x) / 180) >= 0 ? 0 : 180})`;
+        };
+    }
+
+    function getTransformData(data) {
+        // d3.interpolate should not try to interpolate other properties
+        return (({ value, x0, x1, y0, y1 }) => ({ value, x0, x1, y0, y1 }))(data);
+    }
+
+
 
     donutState.context.signalRenderComplete();
 }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -67,9 +67,10 @@ export async function render(donutState) {
             (enter) => {
                 return enter
                     .append("text")
+                    .attr("fill", donutState.context.styling.general.font.color)
                     .style("opacity", 1)
                     .attr("dy", "0.35em")
-                    .attr("font-size", 12)
+                    .attr("font-size", donutState.context.styling.general.font.fontSize)
                     .attr("text-anchor", "middle")
                     .attr("overflow", "visible")
                     .text((d) => (d.data.value / donutState.sumOfValues * 100).toFixed(1) + "%")
@@ -89,6 +90,7 @@ export async function render(donutState) {
                         .style("opacity", 1)
                         .text((d) => (d.data.value / donutState.sumOfValues * 100).toFixed(1) + "%")
                         .attr("transform", calculateLabelPosition)
+                        .attr("fill", donutState.context.styling.general.font.color)
 
                 ),
             (exit) => exit.transition("remove labels").duration(animationDuration).style("opacity", 0).remove()

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -71,9 +71,9 @@ export async function render(donutState) {
                     .style("opacity", 1)
                     .attr("dy", "0.35em")
                     .attr("font-size", donutState.context.styling.general.font.fontSize)
+                    .text((d) => (calculatePercentageValue(d) + "%"))
                     .attr("text-anchor", "middle")
                     .attr("overflow", "visible")
-                    .text((d) => (d.data.value / donutState.sumOfValues * 100).toFixed(1) + "%")
                     .call((enter) =>
                         enter
                             .transition("add labels")
@@ -88,7 +88,7 @@ export async function render(donutState) {
                         .transition("update labels")
                         .duration(animationDuration)
                         .style("opacity", 1)
-                        .text((d) => (d.data.value / donutState.sumOfValues * 100).toFixed(1) + "%")
+                        .text((d) => (calculatePercentageValue(d) + "%"))
                         .attr("transform", calculateLabelPosition)
                         .attr("fill", donutState.context.styling.general.font.color)
 
@@ -111,12 +111,20 @@ export async function render(donutState) {
 
     function calculateLabelPosition(data){
         let centeringFactor = radius * 0.75
-        let c = arc.centroid(data)
-        let x = c[0]
-        let y = c[1]
+        let centroid = arc.centroid(data)
+        let x = centroid[0]
+        let y = centroid[1]
         let h = Math.sqrt(x * x + y * y);
         return "translate(" + (x/h * centeringFactor) +  ',' + (y/h * centeringFactor) +  ")";
 
+    }
+
+    // Calculates the percentage value for a set numerator and denominator and returns it
+    // with a set "decimalPlaces" accuracy
+    //http://www.jacklmoore.com/notes/rounding-in-javascript/
+    function calculatePercentageValue(d) {
+        let decimalPlaces = 1;
+        return Number(Math.round(parseFloat((d.data.value / donutState.sumOfValues * 100) + 'e' + decimalPlaces)) + 'e-' + decimalPlaces);
     }
 
     donutState.context.signalRenderComplete();

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -115,7 +115,6 @@ export async function render(donutState) {
         let x = c[0]
         let y = c[1]
         let h = Math.sqrt(x * x + y * y);
-        console.log(h)
         return "translate(" + (x/h * centeringFactor) +  ',' + (y/h * centeringFactor) +  ")";
 
     }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -14,7 +14,7 @@ export async function render(donutState) {
 
     d3.select("#mod-container svg").attr("width", width).attr("height", height);
 
-    const svg = d3.select("#mod-container").select("svg#svg").attr("transform", `translate(${width / 2}, ${height / 2})`);
+    const svg = d3.select("#mod-container svg g").attr("transform", `translate(${width / 2}, ${height / 2})`);
 
     const pie = d3.pie().value((d) => d.value);
 
@@ -65,10 +65,10 @@ export async function render(donutState) {
             (enter) => {
                 return enter
                     .append("text")
-                    .style("opacity", 0)
+                    .style("opacity", 1)
                     .attr("dy", "0.35em")
                     .attr("font-size", 40)
-                    .attr("fill", "transparent")
+                    .attr("overflow", "visible")
                     .text((d) => (d.data.value / donutState.sumOfValues * 100).toFixed(1))
                     .call((enter) =>
                         enter
@@ -112,7 +112,11 @@ export async function render(donutState) {
         return (({ value, x0, x1, y0, y1 }) => ({ value, x0, x1, y0, y1 }))(data);
     }
 
-
+    function labelPosition(d) {
+        const x = (((d.x0 + d.x1) / 2) * 180) / Math.PI;
+        const y = (d.y0 + d.y1) / 2;
+        return { x, y };
+    }
 
     donutState.context.signalRenderComplete();
 }

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -17,8 +17,11 @@
     </head>
     <body>
         <div id="mod-container">
-            <svg>
-                <g></g>
+            <svg id="svg">
+                <g id="container">
+                    <g id="sectors"></g>
+                    <g id="labels"></g>
+                </g>
             </svg>
         </div>
         <script id="spotfire-loader">var Spotfire=function(e){"use strict";return e.initialize=function(e){var t="sfTemp"+1e4*Math.random()+"Cb",r=window;r[t]=e;var a={subject:"GetUrl",callbackId:-1,options:{cbId:t}};r.addEventListener("message",(function e(t){if(t.source!==r.parent||!t.data.src)return;r.removeEventListener("message",e);var a=document,n=a.createElement("script");n.src=t.data.src,(a.head||a.body).appendChild(n)})),r.parent.postMessage(a,"*")},e}({});</script>

--- a/src/static/main.css
+++ b/src/static/main.css
@@ -18,7 +18,7 @@ body {
     display: inherit;
 }
 text {
-    font: 10px sans-serif;
+    font: 20px sans-serif;
 }
 form {
     position: absolute;

--- a/src/static/main.css
+++ b/src/static/main.css
@@ -17,9 +17,6 @@ body {
     margin: auto;
     display: inherit;
 }
-text {
-    font: 20px sans-serif;
-}
 form {
     position: absolute;
     right: 10px;


### PR DESCRIPTION
## Related issue
- Helps DMT-30

## Proposed changes
- Adds corresponding percentage value labels to each partition in the donut

## Additional information 
- Not a final implementation, corner cases to be added, font styling needs to be fixed relative to visualization size etc.
