### PR TITLE
DMT-35 implement sector-hovering stroke

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -54,6 +54,10 @@ export async function render(donutState) {
         })
         .on("mouseleave", function () {
             donutState.modControls.tooltip.hide();
+            d3.select(this).style("stroke", "none")
+        })
+        .on("mouseover", function (){
+            d3.select(this).style("stroke", donutState.context.styling.general.font.color)
         })
         .attr("fill", () => "transparent");
 


### PR DESCRIPTION
## Related issue
- Closes DMT-35

## Proposed changes
- Implement the stroke marking of a sector when hovering it with mouseover
- works with both light and dark mode

