### PR TITLE
DMT-14 Label fonts

### DIFF
--- a/src/donutState.js
+++ b/src/donutState.js
@@ -103,7 +103,10 @@ export async function createDonutState(mod) {
         clearMarking: () => dataView.clearMarking(),
         styles: {
             fontColor: context.styling.general.font.color,
-            fontFamily: context.styling.general.font.fontFamily,
+            fontFamily:
+                context.styling.general.font.fontFamily.indexOf(",") > -1
+                    ? context.styling.general.font.fontFamily.split(",")[0]
+                    : context.styling.general.font.fontFamily,
             fontWeight: context.styling.general.font.fontWeight,
             fontSize: context.styling.general.font.fontSize
         }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -145,6 +145,9 @@ export async function render(donutState) {
                         .text((d) => d.data.absPercentage + "%")
                         .attr("transform", calculateLabelPosition)
                         .attr("fill", donutState.styles.fontColor)
+                        .attr("font-family", donutState.styles.fontFamily)
+                        .attr("font-weight", donutState.styles.fontWeight)
+                        .attr("font-size", donutState.styles.fontSize)
                 ),
             (exit) => exit.transition("remove labels").duration(animationDuration).style("opacity", 0).remove()
         );

--- a/src/static/main.css
+++ b/src/static/main.css
@@ -19,6 +19,7 @@ body,
     justify-self: center;
     align-items: center;
     overflow-y: auto;
+    font-family: sans-serif;
 }
 
 svg {


### PR DESCRIPTION
## Related issue
- DMT-14, Closses #45 

## Proposed changes
- Update font-family logic in order to use the chosen font style in the custom visualization 
- Add backup font family in the main CSS as the one used in Spotfire 
