### PR TITLE
DMT-33 Rename y-axis

### DIFF
--- a/src/donutState.js
+++ b/src/donutState.js
@@ -15,7 +15,7 @@ export async function createDonutState(mod) {
     const dataView = await mod.visualization.data();
     const size = await mod.windowSize();
     const context = await mod.getRenderContext();
-    const yAxisName = "Sector size by:";
+    const yAxisName = "Sector size by";
 
     /**
      * Check for any errors.

--- a/src/static/mod-manifest.json
+++ b/src/static/mod-manifest.json
@@ -14,7 +14,7 @@
         },
         "axes": [
             {
-                "name": "Sector size by:",
+                "name": "Sector size by",
                 "mode": "continuous",
                 "placement": "none"
             }


### PR DESCRIPTION
## Related issue
Closes DMT-33, closes #38 

## Proposed changes
- Simply a fix for a spelling error in the code and on the UI.

## Additional information // Optional
- Was previously resolved in #31 , but reopened due to a spelling error.