### PR TITLE
Rectangle selection colour

### DIFF
--- a/src/static/main.css
+++ b/src/static/main.css
@@ -30,8 +30,8 @@ svg {
     fill: #85A2CB;
     stroke: #313336;
     fill-opacity: 0.5;
-    stroke-opacity: 0.5;
-    stroke-width: 0.1;
+    stroke-opacity: 1;
+    stroke-width: 0.5;
 }
 
 .outerSectorArc {


### PR DESCRIPTION
## Related issue
- Closes DMT-58, closes #42 

## Proposed changes
- Added the correct colours and opacities for the stroke and fill of the rectangle.
- The colour and stroke should now match the colours in the browser client. 

## Additional information 
- Colours are not similar between the desktop client and the browser client, but the customers specified that the browser client was the priority.
