### PR TITLE
DMT-70 Bugfix for no center value selected

### DIFF
--- a/src/donutState.js
+++ b/src/donutState.js
@@ -75,13 +75,10 @@ export async function createDonutState(mod) {
         data = colorLeaves.map((leaf) => {
             let rows = leaf.rows();
             let yValue = sumValue(rows, resources.yAxisName);
-            let centerSum = 0;
+            let centerSum = dataViewCenterAxis != null ? sumValue(rows, resources.centerAxisName) : null;
             let percentage = calculatePercentageValue(yValue, totalYSum, 1);
             let absPercentage = Math.abs(percentage).toFixed(1);
 
-            if (dataViewCenterAxis != null) {
-                centerSum = sumValue(rows, resources.centerAxisName);
-            }
             return {
                 color: rows.length ? rows[0].color().hexCode : "transparent",
                 value: yValue,

--- a/src/donutState.js
+++ b/src/donutState.js
@@ -56,12 +56,6 @@ export async function createDonutState(mod) {
     }
 
     let dataViewCenterAxis = await dataView.continuousAxis(resources.centerAxisName);
-    if (dataViewCenterAxis == null) {
-        mod.controls.errorOverlay.show("No data on center axis.", resources.centerAxisName);
-        return;
-    } else {
-        mod.controls.errorOverlay.hide(resources.yAxisName);
-    }
 
     // Hide tooltip
     mod.controls.tooltip.hide();
@@ -81,9 +75,13 @@ export async function createDonutState(mod) {
         data = colorLeaves.map((leaf) => {
             let rows = leaf.rows();
             let yValue = sumValue(rows, resources.yAxisName);
-            let centerSum = sumValue(rows, resources.centerAxisName);
+            let centerSum = 0;
             let percentage = calculatePercentageValue(yValue, totalYSum, 1);
             let absPercentage = Math.abs(percentage).toFixed(1);
+
+            if (dataViewCenterAxis != null) {
+                centerSum = sumValue(rows, resources.centerAxisName);
+            }
             return {
                 color: rows.length ? rows[0].color().hexCode : "transparent",
                 value: yValue,

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -3,6 +3,7 @@ import * as marker from "./marker";
 import { calculatePercentageValue, roundNumber } from "./utility";
 import { applyHoverEffect } from "./hoverer";
 import { initializeSettingsPopout } from "./popout";
+import { resources } from "./resources";
 
 /**
  * @param {object} donutState
@@ -17,6 +18,8 @@ export async function render(donutState, modProperty) {
 
     const width = donutState.size.width - sizeModifier;
     const height = donutState.size.height - sizeModifier;
+
+    const centerAxis = await donutState.dataView.continuousAxis(resources.centerAxisName);
 
     if (height <= 0 || width <= 0) {
         return;
@@ -67,7 +70,11 @@ export async function render(donutState, modProperty) {
         .style("font-family", donutState.styles.fontFamily)
         .style("font-size", donutState.styles.fontSize);
 
-    calculateMarkedCenterText(donutState.data);
+    if (centerAxis != null) {
+        calculateMarkedCenterText(donutState.data);
+    } else {
+        centerColorText.text(resources.noSelectedCenterValue).style("opacity", 1);
+    }
 
     // Join new data
     const sectors = svg

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -3,7 +3,6 @@ import * as marker from "./marker";
 import { calculatePercentageValue, roundNumber } from "./utility";
 import { applyHoverEffect } from "./hoverer";
 import { initializeSettingsPopout } from "./popout";
-import { resources } from "./resources";
 
 /**
  * @param {object} donutState
@@ -18,8 +17,6 @@ export async function render(donutState, modProperty) {
 
     const width = donutState.size.width - sizeModifier;
     const height = donutState.size.height - sizeModifier;
-
-    const centerAxis = await donutState.dataView.continuousAxis(resources.centerAxisName);
 
     if (height <= 0 || width <= 0) {
         return;
@@ -70,11 +67,7 @@ export async function render(donutState, modProperty) {
         .style("font-family", donutState.styles.fontFamily)
         .style("font-size", donutState.styles.fontSize);
 
-    if (centerAxis != null) {
-        calculateMarkedCenterText(donutState.data);
-    } else {
-        centerColorText.text(resources.noSelectedCenterValue).style("opacity", 1);
-    }
+    calculateMarkedCenterText(donutState.data);
 
     // Join new data
     const sectors = svg
@@ -85,15 +78,15 @@ export async function render(donutState, modProperty) {
         });
 
     const labelColorLuminance = calculateLuminance(
-        parseInt(donutState.styles.fontColor.substr(1,2),16),
-        parseInt(donutState.styles.fontColor.substr(3,2),16),
-        parseInt(donutState.styles.fontColor.substr(5,2),16)
+        parseInt(donutState.styles.fontColor.substr(1, 2), 16),
+        parseInt(donutState.styles.fontColor.substr(3, 2), 16),
+        parseInt(donutState.styles.fontColor.substr(5, 2), 16)
     );
 
     const backgroundLuminance = calculateLuminance(
-        parseInt(donutState.styles.backgroundColor.substr(1,2),16),
-        parseInt(donutState.styles.backgroundColor.substr(3,2),16),
-        parseInt(donutState.styles.backgroundColor.substr(5,2),16)
+        parseInt(donutState.styles.backgroundColor.substr(1, 2), 16),
+        parseInt(donutState.styles.backgroundColor.substr(3, 2), 16),
+        parseInt(donutState.styles.backgroundColor.substr(5, 2), 16)
     );
 
     let newSectors = sectors
@@ -182,10 +175,14 @@ export async function render(donutState, modProperty) {
 
         // Check if background luminance is closer to dark background color
         if (backgroundLuminance < 0.5) {
-            return contrastToLabelColor(sectorColor) > 1.7 ? donutState.styles.fontColor : donutState.styles.backgroundColor;
+            return contrastToLabelColor(sectorColor) > 1.7
+                ? donutState.styles.fontColor
+                : donutState.styles.backgroundColor;
         }
 
-        return contrastToLabelColor(sectorColor) > 2.7 ? donutState.styles.fontColor : donutState.styles.backgroundColor;
+        return contrastToLabelColor(sectorColor) > 2.7
+            ? donutState.styles.fontColor
+            : donutState.styles.backgroundColor;
     }
 
     /**
@@ -197,9 +194,9 @@ export async function render(donutState, modProperty) {
      */
     function contrastToLabelColor(sectorColor) {
         let fillLuminance = calculateLuminance(
-            parseInt(sectorColor.substr(1,2),16),
-            parseInt(sectorColor.substr(3,2),16),
-            parseInt(sectorColor.substr(5,2),16)
+            parseInt(sectorColor.substr(1, 2), 16),
+            parseInt(sectorColor.substr(3, 2), 16),
+            parseInt(sectorColor.substr(5, 2), 16)
         );
         // Calculating the relative luminance for the brightest of the colors
         let brightest = Math.max(fillLuminance, labelColorLuminance);
@@ -218,8 +215,8 @@ export async function render(donutState, modProperty) {
      */
     function calculateLuminance(r, g, b) {
         var a = [r, g, b].map(function (v) {
-           v /= 255;
-           return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+            v /= 255;
+            return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
         });
         return a[0] * 0.2126 + a[1] * 0.7152 + a[2] * 0.0722;
     }
@@ -278,6 +275,13 @@ export async function render(donutState, modProperty) {
     function calculateMarkedCenterText(data) {
         let centerTotal = 0;
         let markedSectors = [];
+
+        if (data.length > 0 && data[0].centerSum === null) {
+            return;
+        } else if (data.length === 0) {
+            return;
+        }
+
         for (let i = 0; i < data.length; i++) {
             if (data[i].markedRowCount() > 0) {
                 centerTotal += data[i].centerSum;
@@ -314,10 +318,10 @@ export async function render(donutState, modProperty) {
             .duration(animationDuration)
             .style("opacity", "1");
         if (d.data.markedRowCount() === 0 && centerText.style("opacity") === "0") {
-            centerText.text(roundNumber(d.data.centerSum, 2));
+            centerText.text(d.data.centerSum != null ? roundNumber(d.data.centerSum, 2) : "");
             centerText.style("opacity", 1);
             centerColorText.style("opacity", 1);
-            centerColorText.text(d.data.colorValue);
+            centerColorText.text(d.data.centerSum != null ? d.data.colorValue : "");
         }
     }
     // If editing mode is enabled initialize the setting-popout

--- a/src/resources.js
+++ b/src/resources.js
@@ -1,10 +1,13 @@
 export const resources = {
     // Error messages
     errorNoDataOnAxis: (axis) => "No data on " + axis + " axis.",
-    errorGeneralOverlay: "There was an issue with the mod's data; please try reloading. If it persists please check the mod's requirements.",
+    errorGeneralOverlay:
+        "There was an issue with the mod's data; please try reloading. If it persists please check the mod's requirements.",
     errorNullDonutState: (donutState) => "donutState object is " + donutState,
-    errorRendering: "There was an issue related to the rendering of the mod; please try reloading and check the console for more details.",
-    errorCanvasContainerDimensions: "The dimensions of the canvas' container are too small. Please try increasing the canvas' size.",
+    errorRendering:
+        "There was an issue related to the rendering of the mod; please try reloading and check the console for more details.",
+    errorCanvasContainerDimensions:
+        "The dimensions of the canvas' container are too small. Please try increasing the canvas' size.",
 
     // Overlay error categories
     errorOverlayCategoryDataView: "DataView",
@@ -13,6 +16,5 @@ export const resources = {
     // Axis-related
     yAxisName: "Sector size by",
     colorAxisName: "Color",
-    centerAxisName: "Center value by",
-    noSelectedCenterValue: "No center value has been selected to be displayed."
+    centerAxisName: "Center value by"
 };

--- a/src/resources.js
+++ b/src/resources.js
@@ -13,5 +13,6 @@ export const resources = {
     // Axis-related
     yAxisName: "Sector size by",
     colorAxisName: "Color",
-    centerAxisName: "Center value by"
+    centerAxisName: "Center value by",
+    noSelectedCenterValue: "No center value has been selected to be displayed."
 };

--- a/src/resources.js
+++ b/src/resources.js
@@ -16,5 +16,5 @@ export const resources = {
     // Axis-related
     yAxisName: "Sector size by",
     colorAxisName: "Color",
-    centerAxisName: "Center value by"
+    centerAxisName: "Center value"
 };

--- a/src/static/mod-manifest.json
+++ b/src/static/mod-manifest.json
@@ -53,7 +53,7 @@
                 "placement": "none"
             },
             {
-                "name": "Center value by",
+                "name": "Center value",
                 "mode": "continuous",
                 "placement": "none"
             }


### PR DESCRIPTION
## Related issue
- DMT-70
- Closes #63

## Proposed changes
- Fixes the issue when no centre value is selected and the chart crashes
- Introduce behaviour for when no centre value is selected the chart still renders but doesn't display any text in the middle
- Changes the name of the center axis to `Center value` as per #63
