### PR TITLE
DMT-82 Fix selection of sectors despite being marked

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -109,6 +109,9 @@ export async function render(donutState, modProperty) {
     let newSectors = sectors
         .enter()
         .append("svg:path")
+        .attr("id", function (d) {
+            return "sectorID_" + d.data.renderID;
+        })
         .on("click", function (d) {
             marker.select(d);
             d3.event.stopPropagation();


### PR DESCRIPTION
## Related issue
- DMT-82

## Proposed changes
- Update marking logic check for rectangle sides intersection
- Add ids for the sectors
- Add check for path type when selecting with a rectangle in order to avoid unneeded selection for hovering elements 

## Additional information // Optional
- Fixes the bug for marking selection
