### PR TITLE
DMT-84 Format values

### DIFF
--- a/src/donutState.js
+++ b/src/donutState.js
@@ -158,7 +158,10 @@ export async function createDonutState(mod) {
  */
 function formatTotalSum(totalSum) {
     if (totalSum != null) {
-        return roundNumber(totalSum, 2);
+        return roundNumber(totalSum, 2)
+            .toString()
+            .replace(/\B(?=(\d{3})+(?!\d))/g, " ")
+            .replace(".", ",");
     }
     return "";
 }
@@ -216,7 +219,8 @@ function calculateTotalCenterSum(leaves, centerAxisName) {
             rows[0]
                 .continuous(centerAxisName)
                 .formattedValue()
-                .replace(/[^0-9]/g, "")
+                .replace(/[^0-9,]/g, "")
+                .replace(",", ".")
         );
         sumOfValues += centerValue;
     });

--- a/src/donutState.js
+++ b/src/donutState.js
@@ -78,11 +78,11 @@ export async function createDonutState(mod) {
         data = colorLeaves.map((leaf) => {
             let rows = leaf.rows();
             let yValue = sumValue(rows, resources.yAxisName);
-            let currencySymbol = getCurrencySymbolContinuesAxis(rows, resources.centerAxisName);
-            let centerSum = dataViewCenterAxis != null ? sumValue(rows, resources.centerAxisName) : null;
             let percentage = calculatePercentageValue(yValue, totalYSum, 1);
             let absPercentage = Math.abs(percentage).toFixed(1);
-
+            let formattedCenterValue = rows[0].continuous(resources.centerAxisName).formattedValue();
+            let currencySymbol = getCurrencySymbolContinuesAxis(rows, resources.centerAxisName);
+            let lastIndex = getLastCenterIndex(rows, resources.centerAxisName);
             return {
                 color: rows.length ? rows[0].color().hexCode : "transparent",
                 value: yValue,
@@ -91,10 +91,11 @@ export async function createDonutState(mod) {
                 renderID: leaf.leafIndex,
                 percentage: percentage.toFixed(1),
                 absPercentage: absPercentage,
-                centerSum: centerSum,
+                centerSum: formattedCenterValue,
                 currencySymbol: currencySymbol,
+                centerValueSumLastSymbol: lastIndex,
                 colorValue: leaf.formattedValue(),
-                totalCenterSum: roundNumber(totalCenterSum, 2),
+                totalCenterSum: currencySymbol + formatTotalSum(totalCenterSum) + lastIndex,
                 centerTotal: 0,
                 getLabelText: (modProperty) =>
                     createLabelText(
@@ -144,6 +145,17 @@ export async function createDonutState(mod) {
     return donutState;
 }
 
+function formatTotalSum(totalSum) {
+    return roundNumber(totalSum, 2);
+}
+
+function getLastCenterIndex(rows, axisName) {
+    let centerString = rows[0].continuous(axisName).formattedValue();
+    let firstNumberIndex = centerString.search(/\d/);
+    let centerValueSumLastSymbol = centerString.substr(firstNumberIndex, centerString.length - 1);
+    centerValueSumLastSymbol = centerValueSumLastSymbol.replace(/[\d,\s]+/g, "");
+    return centerValueSumLastSymbol;
+}
 /**
  * Calculate the total value for an axis from a set of rows. Null values are treated as 0.
  * @param {Spotfire.DataViewRow[]} rows Rows to calculate the total value from

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -82,7 +82,7 @@ export async function render(donutState, modProperty) {
         .style("font-family", donutState.styles.fontFamily)
         .style("font-size", `${donutState.styles.fontSize * centerValueFontModifier}px`);
     if (donutState.data[0].centerTotal === 0 && donutState.data[0].totalCenterSum != null) {
-        centerText.text(donutState.data[0].currencySymbol + donutState.data[0].totalCenterSum, 2);
+        centerText.text(donutState.data[0].totalCenterSum, 2);
         centerText.style("opacity", 1);
     }
 
@@ -164,7 +164,8 @@ export async function render(donutState, modProperty) {
 
         for (let i = 0; i < data.length; i++) {
             if (data[i].markedRowCount() > 0) {
-                centerTotal += data[i].centerSum;
+                let centerSumNumber = data[i].centerSum.replace(/[^0-9]/g, "");
+                centerTotal += centerSumNumber;
                 markedSectors.push(i);
             }
         }
@@ -172,7 +173,9 @@ export async function render(donutState, modProperty) {
             data[i].centerTotal = centerTotal;
         }
         if (markedSectors.length > 0) {
-            centerText.text(data[0].currencySymbol + roundNumber(centerTotal, 2)).style("opacity", 1);
+            centerText
+                .text(data[0].currencySymbol + roundNumber(centerTotal, 2) + data[0].centerValueSumLastSymbol)
+                .style("opacity", 1);
         }
         if (markedSectors.length === 1) {
             centerColorText.text(data[markedSectors[0]].colorValue).style("opacity", 1);
@@ -187,7 +190,7 @@ export async function render(donutState, modProperty) {
             .duration(animationDuration)
             .style("opacity", "0");
         if (centerText.style("opacity") === "1" && d.data.centerTotal === 0) {
-            centerText.text(d.data.totalCenterSum != null ? d.data.currencySymbol + d.data.totalCenterSum : "");
+            centerText.text(d.data.totalCenterSum != null ? d.data.totalCenterSum : "");
             centerColorText.style("opacity", 0);
         }
     }
@@ -198,7 +201,7 @@ export async function render(donutState, modProperty) {
             .duration(animationDuration)
             .style("opacity", "1");
         if (d.data.centerTotal === 0 && d.data.centerSum != null) {
-            centerText.text(d.data.currencySymbol + roundNumber(d.data.centerSum, 2));
+            centerText.text(d.data.centerSum);
             centerText.style("opacity", 1);
             centerColorText.style("opacity", 1);
             centerColorText.text(d.data.colorValue);

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -82,7 +82,7 @@ export async function render(donutState, modProperty) {
         .style("font-family", donutState.styles.fontFamily)
         .style("font-size", `${donutState.styles.fontSize * centerValueFontModifier}px`);
     if (donutState.data[0].centerTotal === 0 && donutState.data[0].totalCenterSum != null) {
-        centerText.text(roundNumber(donutState.data[0].totalCenterSum, 2));
+        centerText.text(donutState.data[0].currencySymbol + donutState.data[0].totalCenterSum, 2);
         centerText.style("opacity", 1);
     }
 
@@ -172,7 +172,7 @@ export async function render(donutState, modProperty) {
             data[i].centerTotal = centerTotal;
         }
         if (markedSectors.length > 0) {
-            centerText.text(roundNumber(centerTotal, 2)).style("opacity", 1);
+            centerText.text(data[0].currencySymbol + roundNumber(centerTotal, 2)).style("opacity", 1);
         }
         if (markedSectors.length === 1) {
             centerColorText.text(data[markedSectors[0]].colorValue).style("opacity", 1);
@@ -187,7 +187,7 @@ export async function render(donutState, modProperty) {
             .duration(animationDuration)
             .style("opacity", "0");
         if (centerText.style("opacity") === "1" && d.data.centerTotal === 0) {
-            centerText.text(d.data.totalCenterSum != null ? roundNumber(d.data.totalCenterSum, 2) : "");
+            centerText.text(d.data.totalCenterSum != null ? d.data.currencySymbol + d.data.totalCenterSum : "");
             centerColorText.style("opacity", 0);
         }
     }
@@ -198,7 +198,7 @@ export async function render(donutState, modProperty) {
             .duration(animationDuration)
             .style("opacity", "1");
         if (d.data.centerTotal === 0 && d.data.centerSum != null) {
-            centerText.text(roundNumber(d.data.centerSum, 2));
+            centerText.text(d.data.currencySymbol + roundNumber(d.data.centerSum, 2));
             centerText.style("opacity", 1);
             centerColorText.style("opacity", 1);
             centerColorText.text(d.data.colorValue);

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -165,10 +165,7 @@ export async function render(donutState, modProperty) {
         for (let i = 0; i < data.length; i++) {
             if (data[i].markedRowCount() > 0) {
                 // Extract the number from the formatted value string and convert it to a number
-                let variable = data[i].centerSumFormatted.match(/[^\d ]/g);
-                console.log(variable);
-                console.log(data[i].centerSumFormatted);
-                let centerSumNumber = Number(data[i].centerSumFormatted.replace(/[^0-9]/g, ""));
+                let centerSumNumber = Number(data[i].centerSumFormatted.replace(/[^0-9,]/g, "").replace(",", "."));
                 centerTotal += centerSumNumber;
                 markedSectors.push(i);
             }
@@ -178,7 +175,14 @@ export async function render(donutState, modProperty) {
         }
         if (markedSectors.length > 0) {
             centerText
-                .text(data[0].currencySymbol + roundNumber(centerTotal, 2) + data[0].centerValueSumLastSymbol)
+                .text(
+                    data[0].currencySymbol +
+                        roundNumber(centerTotal, 2)
+                            .toString()
+                            .replace(/\B(?=(\d{3})+(?!\d))/g, " ")
+                            .replace(".", ",") +
+                        data[0].centerValueSumLastSymbol
+                )
                 .style("opacity", 1);
         }
         if (markedSectors.length === 1) {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -81,8 +81,8 @@ export async function render(donutState, modProperty) {
         .style("max-width", `${calculateCenterTextSpace()}%`)
         .style("font-family", donutState.styles.fontFamily)
         .style("font-size", `${donutState.styles.fontSize * centerValueFontModifier}px`);
-    if (donutState.data[0].centerTotal === 0 && donutState.data[0].totalCenterSum != null) {
-        centerText.text(donutState.data[0].totalCenterSum, 2);
+    if (donutState.data[0].centerTotal === 0 && donutState.data[0].totalCenterSumFormatted != null) {
+        centerText.text(donutState.data[0].totalCenterSumFormatted, 2);
         centerText.style("opacity", 1);
     }
 
@@ -156,7 +156,7 @@ export async function render(donutState, modProperty) {
         let centerTotal = 0;
         let markedSectors = [];
 
-        if (data.length > 0 && data[0].centerSum === null) {
+        if (data.length > 0 && data[0].centerSumFormatted === null) {
             return;
         } else if (data.length === 0) {
             return;
@@ -164,7 +164,11 @@ export async function render(donutState, modProperty) {
 
         for (let i = 0; i < data.length; i++) {
             if (data[i].markedRowCount() > 0) {
-                let centerSumNumber = data[i].centerSum.replace(/[^0-9]/g, "");
+                // Extract the number from the formatted value string and convert it to a number
+                let variable = data[i].centerSumFormatted.match(/[^\d ]/g);
+                console.log(variable);
+                console.log(data[i].centerSumFormatted);
+                let centerSumNumber = Number(data[i].centerSumFormatted.replace(/[^0-9]/g, ""));
                 centerTotal += centerSumNumber;
                 markedSectors.push(i);
             }
@@ -190,7 +194,7 @@ export async function render(donutState, modProperty) {
             .duration(animationDuration)
             .style("opacity", "0");
         if (centerText.style("opacity") === "1" && d.data.centerTotal === 0) {
-            centerText.text(d.data.totalCenterSum != null ? d.data.totalCenterSum : "");
+            centerText.text(d.data.totalCenterSumFormatted != null ? d.data.totalCenterSumFormatted : "");
             centerColorText.style("opacity", 0);
         }
     }
@@ -200,8 +204,8 @@ export async function render(donutState, modProperty) {
             .transition()
             .duration(animationDuration)
             .style("opacity", "1");
-        if (d.data.centerTotal === 0 && d.data.centerSum != null) {
-            centerText.text(d.data.centerSum);
+        if (d.data.centerTotal === 0 && d.data.centerSumFormatted != null) {
+            centerText.text(d.data.centerSumFormatted);
             centerText.style("opacity", 1);
             centerColorText.style("opacity", 1);
             centerColorText.text(d.data.colorValue);


### PR DESCRIPTION
## Related issue
- Closses #79 DMT-84

## Proposed changes
- Add formatting for labels
- Add formatting for center value
- Both labels and center values use the formatted value from the API
- The center value total sum and marked total are updated to match the styling of the current formatted value from the API using regular expressions
- The formating displays currency(when available) and formats the large numbers(billions) with post-fix "B" as from the API

## Additional information // Optional
- The formatted center total and marked total can be unstable and may lead to inconsistency if the Spotfire API changes, since we are making these calculations locally
- Test suggestions: with "normal" data in center/label values, "price" for currency, and "market value" from "Analyzing stock performance" for the "B" billions post-fix. You can try more data-sets of course
