### PR TITLE
DMT-92 Fix labels text visibility options in popout setting menu

### DIFF
--- a/src/labels.js
+++ b/src/labels.js
@@ -90,16 +90,33 @@ export function addLabels(arc, pie, donutState, modProperty, circleTypeChanged, 
      * @param {donutState.data} d
      */
     function returnLabelText(d) {
+        let text = "";
         if (d.data.absPercentage < resources.sectorHidingPercentageThreshold) {
-            return "";
+            return text;
         }
-        let text = d.data.getLabelText(modProperty);
-        d3.timeout(
-            () => {
-                return adjustLabelTextToFit(d, text);
-            },
-            circleTypeChanged || labelsPositionChanged ? resources.animationDuration : resources.timeoutDelay
-        );
+
+        if (modProperty.labelsVisible.value() === resources.popoutLabelsVisibleAllValue) {
+            text = d.data.getLabelText(modProperty);
+            d3.timeout(
+                () => {
+                    return adjustLabelTextToFit(d, text);
+                },
+                circleTypeChanged || labelsPositionChanged ? resources.animationDuration : resources.timeoutDelay
+            );
+        }
+
+        if (modProperty.labelsVisible.value() === resources.popoutLabelsVisibleMarkedValue) {
+            if (d.data.markedRowCount() > 0) {
+                text = d.data.getLabelText(modProperty);
+                d3.timeout(
+                    () => {
+                        return adjustLabelTextToFit(d, text);
+                    },
+                    circleTypeChanged || labelsPositionChanged ? resources.animationDuration : resources.timeoutDelay
+                );
+            }
+        }
+        return text;
     }
 
     /** Function that adjusts given label's text based on whenever they overlap with the mod-container.


### PR DESCRIPTION
Add checks handling the different cases for the labels' text visibility options, found in the popout setting menu.

## Related issue
- Closes DMT-92

## Proposed changes
- Add checks to handle the different cases for the labels' text visibility options, which can be switched via the popout setting menu entry `show labels for`.
