### PR TITLE
DMT-95 Fix issue with label anchoring for semi-circle

### DIFF
--- a/src/labels.js
+++ b/src/labels.js
@@ -12,7 +12,7 @@ import { checkIfRectanglesGoOutside } from "./utility";
  * @param {boolean} labelsPositionChanged
  */
 export function addLabels(arc, pie, donutState, modProperty, circleTypeChanged, labelsPositionChanged) {
-    const middleRadiansThreshold = modProperty.circleType.value() === resources.popoutCircleTypeSemiValue ? 0 : Math.PI;
+    const middleRadiansThreshold = modProperty.circleType.value() === resources.popoutCircleTypeSemiValue ? 2*Math.PI : Math.PI;
 
     const labelColorLuminance = calculateLuminance(
         parseInt(donutState.styles.fontColor.substr(1, 2), 16),


### PR DESCRIPTION
## Related issue
- Closes DMT-95

## Proposed changes
- Fix the issue with the label anchoring for the semi-circle, when the labels are visualized outside of the semi-circle
- Updated the threshold used based on the newly introduced changes on the start/end angle calculations used for the semi-circle

