### PR TITLE
DMT-103 Update center text's positioning in semi-circle mode

### DIFF
--- a/src/centerText.js
+++ b/src/centerText.js
@@ -40,7 +40,12 @@ export function renderCenterText(donutState, radius, modProperty) {
         .text(donutState.centerExpression);
 
     let centerTextBox = d3.selectAll("#center-text").node().getBoundingClientRect();
-    let yPointDifference = centerTextBox.bottom - height / 2;
+    // Difference in Y-axis between the centerTextBox and the canvas' height,
+    // which affects the positioning of the center text for semi-circle
+    let yPointDifference =
+        width < resources.semiCircleCenterTextPositioningThreshold
+            ? centerTextBox.bottom - height / resources.semiCircleCenterTextDecreasedHeightPositioning
+            : centerTextBox.bottom - height / resources.semiCircleCenterTextIncreasedHeightPositioning;
     let centerTextSemiCircleTransformationHeight =
         donutState.donutCircle.y - centerTextBox.bottom - centerTextBox.height + yPointDifference;
 

--- a/src/resources.js
+++ b/src/resources.js
@@ -79,5 +79,12 @@ export const resources = {
     arcsRadiusOuterOffset: 4.5,
     // Hover highlight sector-sides id prefix/sides identifier
     leftSectorSideIdentifier: "left",
-    rightSectorSideIdentifier: "right"
+    rightSectorSideIdentifier: "right",
+    // The default offset used which affects the positioning of the center text in the Y-axis on semi-circle mode
+    semiCircleCenterTextIncreasedHeightPositioning: 1.9,
+    // Offset used which affects the positioning of the center text in the Y-axis on semi-circle mode, when width is low
+    semiCircleCenterTextDecreasedHeightPositioning: 2,
+    // Threshold for specifying the width value of the canvas, after which the center text shall not follow
+    // the default Y-axis positioning offset
+    semiCircleCenterTextPositioningThreshold: 260
 };


### PR DESCRIPTION
## Related issue
- Closes #112

## Proposed changes
- Update the Y-axis positioning of the center text in semi-circle mode being more placed to the inner part of it. In case of small canvas' width, the previous behavior is being followed, by being placed in the middle of the donut.
