### PR TITLE
#133 Fix issue with duplicate ids for 11.4

### DIFF
--- a/src/donutState.js
+++ b/src/donutState.js
@@ -164,7 +164,9 @@ export async function createDonutState(mod) {
                 yAxis.parts.length !== 0
                     ? yAxis.parts[0].displayName +
                       ": " +
-                   labelFirstSymbols + formatTotalSum(yValue, labelFirstSymbols,labelLastSymbols) + tooltipLabelsLastSymbol +
+                      labelFirstSymbols +
+                      formatTotalSum(yValue, labelFirstSymbols, labelLastSymbols) +
+                      tooltipLabelsLastSymbol +
                       "\n"
                     : "";
             let tooltipFormattedColorValue =
@@ -281,11 +283,13 @@ export async function createDonutState(mod) {
 function createId(leaf) {
     let parts = [];
     let node = leaf;
+    // random number(1-1000) used for replacing values in the id to take account for special character cases that can't be handled in the dom
+    let replaceValue = Math.floor(Math.random() * 1001) + 1;
     while (node) {
         parts.push(node.key != null ? "v:" + node.key : "null");
         node = node.parent;
     }
-    return parts.join("-").replace(/[^\w]/g, "");
+    return parts.join("-").replace(/[^\w]/g, replaceValue + "");
 }
 
 /***


### PR DESCRIPTION
## Related issue
- Closes #133 

## Proposed changes
- Change the id generation logic for 11.4

## Additional information // Optional
- This should resolve the issue with the duplicate ids since the special characters are going to be replaced with numbers. That would make sure that the labels and the dom components don't have duplicate ids as in the bug. 
- There may be a need of more deep investigation and looking into the edge cases. As well as considering the "randomness" 